### PR TITLE
Release/fix start block 0.30.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/graph-cli",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/graph-cli",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/graph-cli",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/src/protocols/ethereum/scaffold/manifest.js
+++ b/src/protocols/ethereum/scaffold/manifest.js
@@ -3,7 +3,8 @@ const ABI = require('../abi')
 
 const source = ({ contract, contractName }) => `
       address: '${contract}'
-      abi: ${contractName}`
+      abi: ${contractName}
+      startBlock: 10`
 
 const mapping = ({ abi, contractName }) => `
       kind: ethereum/events

--- a/src/scaffold/index.js
+++ b/src/scaffold/index.js
@@ -49,7 +49,7 @@ module.exports = class Scaffold {
             this.subgraphName,
         },
         dependencies: {
-          '@graphprotocol/graph-cli': GRAPH_CLI_VERSION,
+          '@nevermined-io/graph-cli': GRAPH_CLI_VERSION,
           '@graphprotocol/graph-ts': `0.24.1`,
         },
       }),

--- a/src/scaffold/mapping.js
+++ b/src/scaffold/mapping.js
@@ -3,7 +3,7 @@ const path = require('path')
 const util = require('../codegen/util')
 
 const generateFieldAssignment = path =>
-  `entity.${path.join('_')} = event.params.${path.join('.')}`
+  `entity.${path.join('_') === 'id' ? '_id' : path.join('_')} = event.params.${path.join('.')}`
 
 const generateFieldAssignments = ({ index, input }) =>
   input.type === 'tuple'

--- a/src/scaffold/schema.js
+++ b/src/scaffold/schema.js
@@ -14,7 +14,7 @@ const protocolTypeToGraphQL = (protocol, name) => {
 }
 
 const generateField = ({ name, type, protocolName }) =>
-  `${name}: ${protocolTypeToGraphQL(protocolName, type)}! # ${type}`
+  `${name === 'id' ? '_id' : name}: ${protocolTypeToGraphQL(protocolName, type)}! # ${type}`
 
 const generateEventFields = ({ index, input, protocolName }) =>
   input.type == 'tuple'


### PR DESCRIPTION
## Description

graph-node does not seem to be able to index when connected to a polygon node if the `startBlock` key is not set

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

